### PR TITLE
Navbar css touch ups

### DIFF
--- a/client/src/components/Episode/episode.css
+++ b/client/src/components/Episode/episode.css
@@ -5,7 +5,7 @@
 
 img {
   margin-top: 25px;
-  margin-left: 10px;
+  /* margin-left: 10px; */
 }
 
 .highlight{

--- a/client/src/components/Navbar/navbar.css
+++ b/client/src/components/Navbar/navbar.css
@@ -54,7 +54,8 @@ button > div {
     color: black !important;
     font-size: 12px;
     font-weight: bold;
-    margin-left: -43em;
+    left: 50%;
+    /* margin-left: -43em; */
     opacity: 1;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/client/src/components/Navbar/navbar.css
+++ b/client/src/components/Navbar/navbar.css
@@ -75,7 +75,6 @@ button > div {
     margin-left: 10px;
     margin-top: 0px;
     position: absolute;
-    right:0;
 }
 
 #topPopupText:after {
@@ -96,7 +95,7 @@ button > div {
 #podcastInput {
     border-radius: 21px;
     text-align: left;
-    width: 170px;
+    width: 250px;
 }
 
 #size {
@@ -114,15 +113,21 @@ button > div {
     width: 100%;
     z-index: 0;
 }
+
 .mobilePosition{
-    position: relative;
-    left: 25.5em;
-    
-    
+    left: 50%;
+    position: fixed;
+    top: 0.7em;
+    transform: translate(-150px);
 }
 
 .navbar-toggler{
     cursor: pointer;
+}
+
+#navContentContainer {
+    margin: 0px;
+    max-width: 100%;
 }
 
 @media only screen and (max-width: 600px) {
@@ -147,9 +152,10 @@ button > div {
     }
 
     .mobilePosition{
+        left: 50%;
         position: fixed;
-        left: 25%;
         top: 0.7em;
+        transform: translate(-150px);
     }
 
     .navbarAudioPopup{
@@ -157,7 +163,7 @@ button > div {
     }
   }
 
-  @media only screen and (max-width: 400px) {
+  /* @media only screen and (max-width: 400px) {
     .mobilePosition{
         left: 17%;
     }
@@ -167,4 +173,4 @@ button > div {
     .mobilePosition{
         left: 12%;
     }
-  }
+  } */

--- a/client/src/components/Navbar/navbar.js
+++ b/client/src/components/Navbar/navbar.js
@@ -93,7 +93,7 @@ class Navbar extends Component {
     return (
 
       <nav className={`navbar navbar-expand-lg navbar-${theme} bg-${theme} sticky-top`}>
-        <div className="container fluid">
+        <div className="container fluid" id="navContentContainer">
 
           {/* Podhub Logo */}
 

--- a/client/src/pages/Listen.css
+++ b/client/src/pages/Listen.css
@@ -16,6 +16,7 @@
     font-weight: bold;
     font-size: 19px;
     margin-bottom: 20px;
+    overflow: visible;
 }
 
 


### PR DESCRIPTION
Navbar: 
1) Spaced navbar/elements across entire width of page
2) Centered Navbar Audio Player
3) Widened podcast search box from 170px to 250px

Listen Page: 
1) Removed overflow property from episode title to prevent text cutoff
2) Removed margin-left from podcast logo for proper centering