### PR TITLE
SetLastCheckedNotifications

### DIFF
--- a/client/src/components/Navbar/navbar.js
+++ b/client/src/components/Navbar/navbar.js
@@ -101,8 +101,8 @@ class Navbar extends Component {
       isAlert: false
     });
 
-
-    API.lastCheckedNotification(this.props.user.id, moment().format())
+    API.lastCheckedNotification(this.props.user.id, 
+      {notificationsSeen: moment().format()} )
       .then(res => { })
   }
 

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -301,7 +301,7 @@ export default {
     },
 
     // Save a record of the date and time when user has checked his notifications last time 
-    lastCheckedNotification: function (userId, time) {
-        return axios.put("api/users/" + userId + time + "/lastCheckedNotification")
+    lastCheckedNotification: function (userId, body) {
+        return axios.put("api/users/" + userId + "/lastCheckedNotification", body)
     }
 };

--- a/controllers/CommentController.js
+++ b/controllers/CommentController.js
@@ -47,7 +47,7 @@ class CommentController {
         db.user.findByPk(req.body.userId).then(function(likedBy){
           res.json(dbCommentLike);
 
-          if(comment.commentedBy != req.body.userId){
+          if(comment.commentedBy != req.body.userId && dbCommentLike[1] === true){
             server.notification.notifyCommentLike(comment.commentedBy, likedBy.name, comment.comment);
             db.notification.create(
               {

--- a/controllers/PostController.js
+++ b/controllers/PostController.js
@@ -41,7 +41,7 @@ class PostController {
         db.user.findByPk(req.body.userId).then(function(likedBy){
           res.json(dbPostLike);
           
-          if(post.postedBy != req.body.userId) {
+          if(post.postedBy != req.body.userId && dbPostLike[1] === true) {
             server.notification.notifyPostLike(post.postedBy, likedBy.name, post.episodeName);
             db.notification.create(
               {

--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -334,7 +334,7 @@ class UserController {
  getNotifications(req, res)
  {
    db.notification.findAll({
-    offset: 0, limit: 20,
+    offset: 0, limit: 30,
      where: {
       userId: req.params.id
      }
@@ -344,5 +344,6 @@ class UserController {
 
  }
 }
+
 
 module.exports = UserController;

--- a/routes/api/userRoute.js
+++ b/routes/api/userRoute.js
@@ -126,4 +126,12 @@ router.post("/unfollow", (req, res) => controller.unFollow(req, res));
 router.get("/:id/notifications", (req, res) => controller.getNotifications(req, res));
 
 
+/**
+ * Put Last Checked Notifications <<--------------Notification page------------->>
+ * @param {*} req
+ * @param {*} res
+ */
+router.put("/:id/lastCheckedNotification", (req, res) => controller.update(req, res));
+
+
 module.exports = router;


### PR DESCRIPTION
 1. (Mary) Update back-end to not save record when user unlikes post or comment
    2.  (Mary) Limit notification history not by 20 but by last 30 days and sort it so that recent notifications stay on top. It's simple solution to avoid pagination and tokens.
    4. (Mary) Create route `lastCheckedNotification` that saves date/time when user last time clicked on notification buttons. Front end for both routes already exists in master.